### PR TITLE
Added opacity to app-icon

### DIFF
--- a/index.css
+++ b/index.css
@@ -79,6 +79,11 @@ nav ul {
 .app-icon {
     width: 45%;
     margin-right: -15px;
+    transition: all 150ms ease-in;
+}
+
+.app-icon:hover {
+    opacity: 0.65;
 }
 
 nav ul li{


### PR DESCRIPTION
Fixes #12 
As the icon is black, you can't make it "brighter", black is black, so a good way is to drop opacity of a black item to appear lighter on hover, also added a nice 150ms transition so looks smoother